### PR TITLE
Fixed Bat for FL64 Launch

### DIFF
--- a/FLStudioRPC.bat
+++ b/FLStudioRPC.bat
@@ -4,7 +4,7 @@ setlocal
 :: Define paths
 set "scriptDir=%~dp0"
 set "scriptPath=%scriptDir%\FLStudioRPC.bat"
-set "fl64Path=%scriptDir%FL64.exe"
+set "fl64Path=%scriptDir%..\FL64.exe"
 set "flstudioRPCPath=%scriptDir%assets\FLStudioRPC.exe"
 set "iconPath=%scriptDir%assets\icon.ico"
 set "shortcutName=FL Studio RPC"

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ To set up the FL Studio Discord Rich Presence integration, follow these steps:
   - This setup assumes that you have FL Studio installed and that the executables and assets are correctly placed in the same directory as `FL64.exe`.
 
 ## Changelog
+### v1.0.1
+- Batch script fix
+
 ### v1.0.0
 - First public working release
 - In future updates there may not be any need for the exe file or batch script, Rich presence will work automatically when opening FL Studio.


### PR DESCRIPTION
Fixed the Batch file for FL64 Launch.

When moving the extracted folder to FL's Program Directory, the current batch file didn't account for FL64.exe to be in one directory above the script. I also confirmed that the shortcut creation will create with the icon.